### PR TITLE
Fixed bug with iTerm2 3.0 not opening

### DIFF
--- a/Classes/ElasticsAppDelegate.m
+++ b/Classes/ElasticsAppDelegate.m
@@ -1255,11 +1255,9 @@ static NSImage *_brImage;
 					
 					cmd = [NSString stringWithFormat:
 						   @"tell application \"iTerm\"\n"
-						   @"	activate\n"
-						   @"	set myterm to (make new terminal)\n"
-						   @"	tell myterm\n"
-						   @"		launch session \"Default Session\"\n"
-						   @"		tell the last session\n"
+						   @"	set newWindow to (create window with default profile)\n"
+						   @"	tell newWindow\n"
+						   @"		tell current session\n"
 						   @"			write text \"%@\"\n"
 						   @"		end tell\n"
 						   @"	end tell\n"


### PR DESCRIPTION
Applescript to launch terminal on a new window was not working for iTerm2 3.0. 
